### PR TITLE
merge_json.pyにデータ整形用の記述を追加

### DIFF
--- a/Python/merge_json.py
+++ b/Python/merge_json.py
@@ -1,28 +1,74 @@
-import os
-import json
 import glob
+import html
+import json
+import os
 import re
+import unicodedata
+
 
 def parse_filename(filename):
     # ファイル名からカテゴリ、年、問題番号を抽出
-    pattern = r'([a-z]+)-(\d{4})-(\d+)\.json'
+    pattern = r"([a-z]+)-(\d{4})-(\d+)\.json"
     match = re.match(pattern, os.path.basename(filename))
-    
+
     if match:
         return {
-            'category': match.group(1),
-            'year': int(match.group(2)),
-            'problem_number': int(match.group(3))
+            "category": match.group(1),
+            "year": int(match.group(2)),
+            "problem_number": int(match.group(3)),
         }
     return None
 
+
+def clean_text(s: str) -> str:
+    """HTMLタグ/エンティティ除去、全角→半角、前後空白削除"""
+    s = html.unescape(s)  # HTMLエンティティをアンエスケープ
+    s = re.sub(r"<[^>]+>", "", s)  # タグ除去
+    s = unicodedata.normalize("NFKC", s)  # 全角英数記号を半角化
+    return s.strip()  # 前後空白削除
+
+
+def clean_item(item: dict):
+    """question/select*/answer フィールドに対して一連の整形を行う"""
+    keys = ["question", "select1", "select2", "select3", "select4", "select5", "answer"]
+    # 基本クレンジング
+    for k in keys:
+        if k in item and isinstance(item[k], str):
+            item[k] = clean_text(item[k])
+
+    # selectN に番号と空白を保証
+    for i in range(1, 6):
+        k = f"select{i}"
+        if k in item and isinstance(item[k], str):
+            v = item[k]
+            # 先頭に数字) がなければ付与
+            if not re.match(rf"^{i}\)", v):
+                v = f"{i}) {v}"
+            # 数字) の直後に空白がなければ挿入
+            v = re.sub(rf"^{i}\)(?!\s)", f"{i}) ", v)
+            item[k] = v
+
+    # question は "\n1)" 以降を切り捨て
+    if "question" in item:
+        q = item["question"]
+        idx = q.find("\n1)")
+        if idx >= 0:
+            item["question"] = q[:idx].strip()
+
+    # answer は数値のみカンマ区切り
+    if "answer" in item:
+        nums = re.findall(r"\d+", item["answer"])
+        if nums:
+            item["answer"] = ",".join(nums)
+
+
 def merge_json_files():
     # Web/json配下のすべてのJSONファイルを取得
-    json_files = glob.glob('Python/json/**/*.json', recursive=True)
-    
+    json_files = glob.glob("Python/json/**/*.json", recursive=True)
+
     # マージしたデータを保存するリスト
     merged_data = []
-    
+
     # 各JSONファイルを読み込んでマージ
     for file_path in json_files:
         try:
@@ -31,33 +77,34 @@ def merge_json_files():
             if not file_info:
                 print(f"Warning: Could not parse filename: {file_path}")
                 continue
-                
-            with open(file_path, 'r', encoding='utf-8') as f:
+
+            with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 # データを処理
                 if isinstance(data, dict):
-                    # 既存のデータにファイル情報を追加
                     data.update(file_info)
+                    clean_item(data)
                     merged_data.append(data)
                 elif isinstance(data, list):
-                    # リストの各要素にファイル情報を追加
                     for item in data:
                         if isinstance(item, dict):
                             item.update(file_info)
+                            clean_item(item)
                             merged_data.append(item)
                 print(f"Processed: {file_path}")
         except Exception as e:
             print(f"Error processing {file_path}: {e}")
-    
+
     # マージしたデータを新しいJSONファイルに書き出し
-    output_file = 'Python/merged_output.json'
+    output_file = "Python/merged_output.json"
     try:
-        with open(output_file, 'w', encoding='utf-8') as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             json.dump(merged_data, f, ensure_ascii=False, indent=2)
         print(f"\nMerge completed! Total {len(merged_data)} items merged.")
         print(f"Output file: {output_file}")
     except Exception as e:
         print(f"Error writing output file: {e}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     merge_json_files()


### PR DESCRIPTION
現在の`merged_output.json`は医療情報技師試験対策wikiからコピーして来た問題や解答をそのままjsonに落とし込んでいるため、正解を2つ選ぶ問題で形式の不一致により本来正解の問題が不正解判定されることがあります。このような問題に対応するため、`merge_json.py`に以下の要件を満たす記述を追加しました。

* "question", "select1", "select2", "select3", "select4", "select5", "answer"の値を参照し、値の文のHTML記法を削除する。
* "question", "select1", "select2", "select3", "select4", "select5", "answer"の値を参照し、全角英数字を半角に直す。
* "question", "select1", "select2", "select3", "select4", "select5", "answer"の値を参照し、冒頭及び末尾の空白文字を削除する。
* "select1", "select2", "select3", "select4", "select5"の値を参照し、冒頭に番号がついていない場合は "1)" のような形でつける。その後、番号と以降の文の間にスペースが空いていない場合はスペースを挿入する。
* "question"の値を参照し、"\n1)"以降を削除する。
"answer"の値を参照し、数字が一つだけの場合は数字のみ、2つの場合は "1,2" のようなかたちで間にカンマのみをいれる。